### PR TITLE
Issue#7 アーキテクチャを適用

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2478F362271B30F000620766 /* GitHubRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2478F361271B30F000620766 /* GitHubRepository.swift */; };
-		2478F366271F051A00620766 /* RepositoryPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2478F365271F051A00620766 /* RepositoryPresenter.swift */; };
+		2478F366271F051A00620766 /* SearchRepositoryPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2478F365271F051A00620766 /* SearchRepositoryPresenter.swift */; };
 		2478F369271F12BF00620766 /* Instantiate in Frameworks */ = {isa = PBXBuildFile; productRef = 2478F368271F12BF00620766 /* Instantiate */; };
 		2478F36B271F12BF00620766 /* InstantiateStandard in Frameworks */ = {isa = PBXBuildFile; productRef = 2478F36A271F12BF00620766 /* InstantiateStandard */; };
 		2478F36D271F18C300620766 /* RepositoryViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2478F36C271F18C300620766 /* RepositoryViewController.storyboard */; };
@@ -42,7 +42,7 @@
 
 /* Begin PBXFileReference section */
 		2478F361271B30F000620766 /* GitHubRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepository.swift; sourceTree = "<group>"; };
-		2478F365271F051A00620766 /* RepositoryPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryPresenter.swift; sourceTree = "<group>"; };
+		2478F365271F051A00620766 /* SearchRepositoryPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryPresenter.swift; sourceTree = "<group>"; };
 		2478F36C271F18C300620766 /* RepositoryViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RepositoryViewController.storyboard; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -116,7 +116,7 @@
 				BFD945E2244DC5E80012785A /* SearchViewController.swift */,
 				BF0A658C244F2A3B00280FA6 /* RepositoryViewController.swift */,
 				2478F361271B30F000620766 /* GitHubRepository.swift */,
-				2478F365271F051A00620766 /* RepositoryPresenter.swift */,
+				2478F365271F051A00620766 /* SearchRepositoryPresenter.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
 				2478F36C271F18C300620766 /* RepositoryViewController.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
@@ -285,7 +285,7 @@
 			files = (
 				BFD945E3244DC5E80012785A /* SearchViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryViewController.swift in Sources */,
-				2478F366271F051A00620766 /* RepositoryPresenter.swift in Sources */,
+				2478F366271F051A00620766 /* SearchRepositoryPresenter.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				2478F362271B30F000620766 /* GitHubRepository.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2478F36B271F12BF00620766 /* InstantiateStandard in Frameworks */ = {isa = PBXBuildFile; productRef = 2478F36A271F12BF00620766 /* InstantiateStandard */; };
 		2478F36D271F18C300620766 /* RepositoryViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2478F36C271F18C300620766 /* RepositoryViewController.storyboard */; };
 		24DE3D8A2732DBE400CC394E /* SearchRepositoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DE3D892732DBE400CC394E /* SearchRepositoryModel.swift */; };
+		24DE3D94273AB62300CC394E /* ImageUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DE3D93273AB62300CC394E /* ImageUtil.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -46,6 +47,7 @@
 		2478F365271F051A00620766 /* SearchRepositoryPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryPresenter.swift; sourceTree = "<group>"; };
 		2478F36C271F18C300620766 /* RepositoryViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RepositoryViewController.storyboard; sourceTree = "<group>"; };
 		24DE3D892732DBE400CC394E /* SearchRepositoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryModel.swift; sourceTree = "<group>"; };
+		24DE3D93273AB62300CC394E /* ImageUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUtil.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 				2478F361271B30F000620766 /* GitHubRepository.swift */,
 				2478F365271F051A00620766 /* SearchRepositoryPresenter.swift */,
 				24DE3D892732DBE400CC394E /* SearchRepositoryModel.swift */,
+				24DE3D93273AB62300CC394E /* ImageUtil.swift */,
 				BFD945E4244DC5E80012785A /* SearchViewController.storyboard */,
 				2478F36C271F18C300620766 /* RepositoryViewController.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
@@ -289,6 +292,7 @@
 				BFD945E3244DC5E80012785A /* SearchViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryViewController.swift in Sources */,
 				2478F366271F051A00620766 /* SearchRepositoryPresenter.swift in Sources */,
+				24DE3D94273AB62300CC394E /* ImageUtil.swift in Sources */,
 				24DE3D8A2732DBE400CC394E /* SearchRepositoryModel.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				2478F362271B30F000620766 /* GitHubRepository.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
 		BFD945E3244DC5E80012785A /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E2244DC5E80012785A /* SearchViewController.swift */; };
-		BFD945E6244DC5E80012785A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E4244DC5E80012785A /* Main.storyboard */; };
+		BFD945E6244DC5E80012785A /* SearchViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E4244DC5E80012785A /* SearchViewController.storyboard */; };
 		BFD945E8244DC5EB0012785A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E7244DC5EB0012785A /* Assets.xcassets */; };
 		BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */; };
 		BFD945F6244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945F5244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift */; };
@@ -51,7 +51,7 @@
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BFD945E0244DC5E80012785A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		BFD945E2244DC5E80012785A /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
-		BFD945E5244DC5E80012785A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		BFD945E5244DC5E80012785A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/SearchViewController.storyboard; sourceTree = "<group>"; };
 		BFD945E7244DC5EB0012785A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BFD945EA244DC5EB0012785A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		BFD945EC244DC5EB0012785A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -120,7 +120,7 @@
 				2478F361271B30F000620766 /* GitHubRepository.swift */,
 				2478F365271F051A00620766 /* SearchRepositoryPresenter.swift */,
 				24DE3D892732DBE400CC394E /* SearchRepositoryModel.swift */,
-				BFD945E4244DC5E80012785A /* Main.storyboard */,
+				BFD945E4244DC5E80012785A /* SearchViewController.storyboard */,
 				2478F36C271F18C300620766 /* RepositoryViewController.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
 				BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */,
@@ -261,7 +261,7 @@
 				BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */,
 				2478F36D271F18C300620766 /* RepositoryViewController.storyboard in Resources */,
 				BFD945E8244DC5EB0012785A /* Assets.xcassets in Resources */,
-				BFD945E6244DC5E80012785A /* Main.storyboard in Resources */,
+				BFD945E6244DC5E80012785A /* SearchViewController.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -328,12 +328,12 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		BFD945E4244DC5E80012785A /* Main.storyboard */ = {
+		BFD945E4244DC5E80012785A /* SearchViewController.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
 				BFD945E5244DC5E80012785A /* Base */,
 			);
-			name = Main.storyboard;
+			name = SearchViewController.storyboard;
 			sourceTree = "<group>";
 		};
 		BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */ = {

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2478F369271F12BF00620766 /* Instantiate in Frameworks */ = {isa = PBXBuildFile; productRef = 2478F368271F12BF00620766 /* Instantiate */; };
 		2478F36B271F12BF00620766 /* InstantiateStandard in Frameworks */ = {isa = PBXBuildFile; productRef = 2478F36A271F12BF00620766 /* InstantiateStandard */; };
 		2478F36D271F18C300620766 /* RepositoryViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2478F36C271F18C300620766 /* RepositoryViewController.storyboard */; };
+		24DE3D8A2732DBE400CC394E /* SearchRepositoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DE3D892732DBE400CC394E /* SearchRepositoryModel.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -44,6 +45,7 @@
 		2478F361271B30F000620766 /* GitHubRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepository.swift; sourceTree = "<group>"; };
 		2478F365271F051A00620766 /* SearchRepositoryPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryPresenter.swift; sourceTree = "<group>"; };
 		2478F36C271F18C300620766 /* RepositoryViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RepositoryViewController.storyboard; sourceTree = "<group>"; };
+		24DE3D892732DBE400CC394E /* SearchRepositoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryModel.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				BF0A658C244F2A3B00280FA6 /* RepositoryViewController.swift */,
 				2478F361271B30F000620766 /* GitHubRepository.swift */,
 				2478F365271F051A00620766 /* SearchRepositoryPresenter.swift */,
+				24DE3D892732DBE400CC394E /* SearchRepositoryModel.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
 				2478F36C271F18C300620766 /* RepositoryViewController.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
@@ -286,6 +289,7 @@
 				BFD945E3244DC5E80012785A /* SearchViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryViewController.swift in Sources */,
 				2478F366271F051A00620766 /* SearchRepositoryPresenter.swift in Sources */,
+				24DE3D8A2732DBE400CC394E /* SearchRepositoryModel.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				2478F362271B30F000620766 /* GitHubRepository.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,

--- a/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
@@ -1,56 +1,80 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wFt-RI-uk4">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wFt-RI-uk4">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Root View Controller-->
-        <scene sceneID="0Yw-Vc-k2Q">
+        <scene sceneID="KOV-cM-LnA">
             <objects>
-                <tableViewController id="MOh-CZ-3ki" customClass="SearchViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Fpt-Ev-QNW">
+                <viewController id="qan-5j-HhG" customClass="SearchViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="IG4-L0-aRz">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="zE7-LR-w37">
+                                <rect key="frame" x="0.0" y="88" width="414" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="d4F-ZT-h9t"/>
+                                </constraints>
+                                <textInputTraits key="textInputTraits"/>
+                            </searchBar>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="4rU-Nw-K6r">
+                                <rect key="frame" x="0.0" y="132" width="414" height="764"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Repository" textLabel="NHg-vQ-W2r" detailTextLabel="PSa-8g-oqr" style="IBUITableViewCellStyleValue1" id="8ad-Np-xYr">
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8ad-Np-xYr" id="8G3-wf-34T">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NHg-vQ-W2r">
+                                                    <rect key="frame" x="20" y="12" width="33" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="PSa-8g-oqr">
+                                                    <rect key="frame" x="350" y="12" width="44" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="I02-c9-pXl"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Repository" textLabel="V66-xN-aKy" detailTextLabel="E7E-kF-FF6" style="IBUITableViewCellStyleValue1" id="jZX-YR-etd">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="jZX-YR-etd" id="k29-jL-IM1">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="V66-xN-aKy">
-                                            <rect key="frame" x="20" y="12" width="33" height="20.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="E7E-kF-FF6">
-                                            <rect key="frame" x="350" y="12" width="44" height="20.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="MOh-CZ-3ki" id="mX7-Ab-ERr"/>
-                            <outlet property="delegate" destination="MOh-CZ-3ki" id="A6Y-Dm-cjQ"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" title="Root View Controller" id="ktq-eC-ZBq"/>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="xer-fe-JeW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="4rU-Nw-K6r" secondAttribute="bottom" id="88T-gT-gHK"/>
+                            <constraint firstItem="4rU-Nw-K6r" firstAttribute="trailing" secondItem="I02-c9-pXl" secondAttribute="trailing" id="Aam-E5-G9x"/>
+                            <constraint firstItem="4rU-Nw-K6r" firstAttribute="top" secondItem="zE7-LR-w37" secondAttribute="bottom" id="VDa-iZ-Jhe"/>
+                            <constraint firstItem="4rU-Nw-K6r" firstAttribute="leading" secondItem="I02-c9-pXl" secondAttribute="leading" id="eU7-m6-GUh"/>
+                            <constraint firstItem="zE7-LR-w37" firstAttribute="leading" secondItem="I02-c9-pXl" secondAttribute="leading" id="lJb-gk-kgo"/>
+                            <constraint firstItem="zE7-LR-w37" firstAttribute="trailing" secondItem="I02-c9-pXl" secondAttribute="trailing" id="sWJ-If-iIA"/>
+                            <constraint firstItem="zE7-LR-w37" firstAttribute="top" secondItem="I02-c9-pXl" secondAttribute="top" id="umu-yQ-MW8"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Root View Controller" id="9o2-Y5-KsU"/>
+                    <connections>
+                        <outlet property="searchBar" destination="zE7-LR-w37" id="xyE-Zy-Jn5"/>
+                        <outlet property="tableView" destination="4rU-Nw-K6r" id="1WF-Cs-yK6"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vrt-Nh-Wre" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-498" y="137"/>
+            <point key="canvasLocation" x="-462.31884057971018" y="136.60714285714286"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="hWi-qa-NBR">
@@ -61,7 +85,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
-                        <segue destination="MOh-CZ-3ki" kind="relationship" relationship="rootViewController" id="tOh-FN-tGd"/>
+                        <segue destination="qan-5j-HhG" kind="relationship" relationship="rootViewController" id="HTJ-Ee-Mft"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="scZ-hy-tAz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/iOSEngineerCodeCheck/Base.lproj/SearchViewController.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/SearchViewController.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wFt-RI-uk4">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qan-5j-HhG">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
@@ -8,23 +8,23 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Root View Controller-->
+        <!--Search View Controller-->
         <scene sceneID="KOV-cM-LnA">
             <objects>
-                <viewController id="qan-5j-HhG" customClass="SearchViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="qan-5j-HhG" userLabel="Search View Controller" customClass="SearchViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="IG4-L0-aRz">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="zE7-LR-w37">
-                                <rect key="frame" x="0.0" y="88" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="d4F-ZT-h9t"/>
                                 </constraints>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="4rU-Nw-K6r">
-                                <rect key="frame" x="0.0" y="132" width="414" height="764"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Repository" textLabel="NHg-vQ-W2r" detailTextLabel="PSa-8g-oqr" style="IBUITableViewCellStyleValue1" id="8ad-Np-xYr">
@@ -75,22 +75,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vrt-Nh-Wre" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-462.31884057971018" y="136.60714285714286"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="hWi-qa-NBR">
-            <objects>
-                <navigationController id="wFt-RI-uk4" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iRk-f0-Qkc">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="qan-5j-HhG" kind="relationship" relationship="rootViewController" id="HTJ-Ee-Mft"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="scZ-hy-tAz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-1417" y="137"/>
         </scene>
     </scenes>
     <resources>

--- a/iOSEngineerCodeCheck/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/GitHubRepository.swift
@@ -13,15 +13,29 @@ struct Repositories: Decodable {
 }
 
 struct Repository: Decodable {
-    let full_name: String
+    let fullName: String
     let language: String?
-    let stargazers_count: Int
-    let watchers_count: Int
-    let forks_count: Int
-    let open_issues_count: Int
+    let stargazersCount: Int
+    let watchersCount: Int
+    let forksCount: Int
+    let openIssuesCount: Int
     let owner: Owner
+    
+    enum CodingKeys: String, CodingKey {
+        case fullName = "full_name"
+        case language
+        case stargazersCount = "stargazers_count"
+        case watchersCount = "watchers_count"
+        case forksCount = "forks_count"
+        case openIssuesCount = "open_issues_count"
+        case owner
+    }
 }
 
 struct Owner: Decodable {
-    let avatar_url: String
+    let avatarUrl: String
+    
+    enum CodingKeys: String, CodingKey {
+        case avatarUrl = "avatar_url"
+    }
 }

--- a/iOSEngineerCodeCheck/ImageUtil.swift
+++ b/iOSEngineerCodeCheck/ImageUtil.swift
@@ -1,0 +1,22 @@
+//
+//  ImageUtil.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Matsunobu Shun on 2021/11/09.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+class ImageUtil {
+    
+    class func download(by url: String) async -> UIImage? {
+        guard let imgURL = URL(string: url),
+              let (data, _)  = try? await URLSession.shared.data(from: imgURL) else {
+                  return nil
+              }
+        
+        return UIImage(data: data)
+    }
+    
+}

--- a/iOSEngineerCodeCheck/Info.plist
+++ b/iOSEngineerCodeCheck/Info.plist
@@ -33,16 +33,12 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/iOSEngineerCodeCheck/RepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/RepositoryPresenter.swift
@@ -6,26 +6,45 @@
 //  Copyright © 2021 YUMEMI Inc. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
-class RepositoryPresenter {
+class SearchRepositoryPresenter: SearchPresenter {
     
     private let searchUrl = "https://api.github.com/search/repositories?q=";
     
-    var repositories: [Repository] = []
+    private var repositories: [Repository] = []
+    private var results: [SearchResult] = []
     
-    func request(_ searchWord: String) async {
-        if searchWord.count == 0 {
+    var numberOfElement: Int {
+        get { return repositories.count }
+    }
+    
+    func getElement(at index: Int) -> SearchResult {
+        return results[index]
+    }
+    
+    func didSelectRow(at index: Int) -> UIViewController {
+        return RepositoryViewController(with: repositories[index])
+    }
+    
+    func update(_ searchText: String) async {
+        if searchText.count == 0 {
             return
         }
         
-        guard let encodedWord = searchWord.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+        guard let encodedWord = searchText.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
               let url = URL(string:"\(searchUrl)\(encodedWord)"),
               let (data, _) = try? await URLSession.shared.data(from: url),
               let repositories = try? JSONDecoder().decode(Repositories.self, from: data) else {
                   return
               }
         self.repositories = repositories.items
+        
+        results = []
+        for repository in self.repositories
+        {
+            results.append(SearchResult(title: repository.full_name, detail: repository.language ?? ""))
+        }
     }
     
 }

--- a/iOSEngineerCodeCheck/RepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/RepositoryPresenter.swift
@@ -29,15 +29,26 @@ class SearchRepositoryPresenter: SearchPresenter {
     
     func update(_ searchText: String) async {
         if searchText.count == 0 {
+            print("searchText.count == 0")
             return
         }
         
-        guard let encodedWord = searchText.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-              let url = URL(string:"\(searchUrl)\(encodedWord)"),
-              let (data, _) = try? await URLSession.shared.data(from: url),
-              let repositories = try? JSONDecoder().decode(Repositories.self, from: data) else {
-                  return
-              }
+        guard let encodedWord = searchText.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            print("encodedWord")
+            return
+        }
+        guard let url = URL(string:"\(searchUrl)\(encodedWord)") else {
+            print("url")
+            return
+        }
+        guard let (data, _) = try? await URLSession.shared.data(from: url) else {
+            print("data, _")
+            return
+        }
+        guard let repositories = try? JSONDecoder().decode(Repositories.self, from: data) else {
+            print("repositories")
+            return
+        }
         self.repositories = repositories.items
         
         results = []

--- a/iOSEngineerCodeCheck/RepositoryViewController.storyboard
+++ b/iOSEngineerCodeCheck/RepositoryViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wQt-MI-13B">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wQt-MI-13B">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/iOSEngineerCodeCheck/RepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryViewController.swift
@@ -15,7 +15,6 @@ class RepositoryViewController: UIViewController, StoryboardInstantiatable {
     typealias Dependency = Repository
     
     @IBOutlet weak var thumbnailImageView: UIImageView!
-    
     @IBOutlet weak var repositoryNameLabel: UILabel!
     @IBOutlet weak var languageLabel: UILabel!
     @IBOutlet weak var starsCountLabel: UILabel!
@@ -32,46 +31,23 @@ class RepositoryViewController: UIViewController, StoryboardInstantiatable {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        guard let repo = repository else {
-            return
-        }
-        
-        repositoryNameLabel.text = repo.full_name
-        if let language = repo.language {
+        repositoryNameLabel.text = repository.full_name
+        if let language = repository.language {
             languageLabel.text = "Written in \(language)"
         }
-        starsCountLabel.text = "\(repo.stargazers_count) stars"
-        watchersCountLabel.text = "\(repo.watchers_count) watchers"
-        forksCountLabel.text = "\(repo.forks_count) forks"
-        issuesCountLabel.text = "\(repo.open_issues_count) open issues"
+        starsCountLabel.text = "\(repository.stargazers_count) stars"
+        watchersCountLabel.text = "\(repository.watchers_count) watchers"
+        forksCountLabel.text = "\(repository.forks_count) forks"
+        issuesCountLabel.text = "\(repository.open_issues_count) open issues"
         Task{
-            guard let image = await getImage() else {
+            guard let image = await ImageUtil.download(by: repository.owner.avatar_url) else {
                 return
             }
+            
             DispatchQueue.main.async {
                 self.thumbnailImageView.image = image
             }
         }
-    }
-    
-    func getImage() async -> UIImage? {
-        guard let repo = repository else {
-            return nil
-        }
-        
-        let owner = repo.owner
-        guard let imgURL = URL(string: owner.avatar_url),
-              let (data, _)  = try? await URLSession.shared.data(from: imgURL) else {
-                  return nil
-              }
-        
-        return UIImage(data: data)
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        self.thumbnailImageView.image = nil;
-        self.thumbnailImageView.layer.sublayers = nil;
-        self.thumbnailImageView = nil;
     }
     
 }

--- a/iOSEngineerCodeCheck/RepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryViewController.swift
@@ -31,16 +31,16 @@ class RepositoryViewController: UIViewController, StoryboardInstantiatable {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        repositoryNameLabel.text = repository.full_name
+        repositoryNameLabel.text = repository.fullName
         if let language = repository.language {
             languageLabel.text = "Written in \(language)"
         }
-        starsCountLabel.text = "\(repository.stargazers_count) stars"
-        watchersCountLabel.text = "\(repository.watchers_count) watchers"
-        forksCountLabel.text = "\(repository.forks_count) forks"
-        issuesCountLabel.text = "\(repository.open_issues_count) open issues"
+        starsCountLabel.text = "\(repository.stargazersCount) stars"
+        watchersCountLabel.text = "\(repository.watchersCount) watchers"
+        forksCountLabel.text = "\(repository.forksCount) forks"
+        issuesCountLabel.text = "\(repository.openIssuesCount) open issues"
         Task{
-            guard let image = await ImageUtil.download(by: repository.owner.avatar_url) else {
+            guard let image = await ImageUtil.download(by: repository.owner.avatarUrl) else {
                 return
             }
             

--- a/iOSEngineerCodeCheck/SceneDelegate.swift
+++ b/iOSEngineerCodeCheck/SceneDelegate.swift
@@ -17,7 +17,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let scene = (scene as? UIWindowScene) else {
+            return
+        }
+        let window = UIWindow(windowScene: scene)
+        self.window = window
+        window.makeKeyAndVisible()
+        
+        let storyboard = UIStoryboard(name: "SearchViewController", bundle: nil)
+        guard let viewController = storyboard.instantiateInitialViewController() else {
+            return
+        }
+        
+        let navigationViewController = UINavigationController()
+        navigationViewController.pushViewController(viewController, animated: false)
+        
+        window.rootViewController = navigationViewController
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/iOSEngineerCodeCheck/SceneDelegate.swift
+++ b/iOSEngineerCodeCheck/SceneDelegate.swift
@@ -24,10 +24,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = window
         window.makeKeyAndVisible()
         
-        let storyboard = UIStoryboard(name: "SearchViewController", bundle: nil)
-        guard let viewController = storyboard.instantiateInitialViewController() else {
-            return
-        }
+        let model = SearchRepositoryModel()
+        let presenter = SearchRepositoryPresenter(model: model)
+        let viewController = SearchViewController(with: presenter)
         
         let navigationViewController = UINavigationController()
         navigationViewController.pushViewController(viewController, animated: false)

--- a/iOSEngineerCodeCheck/SearchRepositoryModel.swift
+++ b/iOSEngineerCodeCheck/SearchRepositoryModel.swift
@@ -1,0 +1,43 @@
+//
+//  SearchRepositoryModel.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Matsunobu Shun on 2021/11/04.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+class SearchRepositoryModel: SearchRepositoryModelProtocol {
+    
+    private let searchUrl = "https://api.github.com/search/repositories?q=";
+    
+    enum SearchError: Error {
+        case TextIsEmpty
+        case EncodeFailed
+        case URL
+    }
+    
+    func update(_ searchText: String) async throws -> (repositories: [Repository], results: [SearchResult]) {
+        if searchText.count == 0 {
+            throw SearchError.TextIsEmpty
+        }
+        
+        guard let encodedWord = searchText.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            throw SearchError.EncodeFailed
+        }
+        guard let url = URL(string:"\(searchUrl)\(encodedWord)") else {
+            throw SearchError.URL
+        }
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let repositories = try JSONDecoder().decode(Repositories.self, from: data)
+        
+        var results = [SearchResult]()
+        for repository in repositories.items
+        {
+            results.append(SearchResult(title: repository.full_name, detail: repository.language ?? ""))
+        }
+        
+        return (repositories.items, results)
+    }
+}

--- a/iOSEngineerCodeCheck/SearchRepositoryModel.swift
+++ b/iOSEngineerCodeCheck/SearchRepositoryModel.swift
@@ -35,7 +35,7 @@ class SearchRepositoryModel: SearchRepositoryModelProtocol {
         var results = [SearchResult]()
         for repository in repositories.items
         {
-            results.append(SearchResult(title: repository.full_name, detail: repository.language ?? ""))
+            results.append(SearchResult(title: repository.fullName, detail: repository.language ?? ""))
         }
         
         return (repositories.items, results)

--- a/iOSEngineerCodeCheck/SearchRepositoryModel.swift
+++ b/iOSEngineerCodeCheck/SearchRepositoryModel.swift
@@ -13,21 +13,21 @@ class SearchRepositoryModel: SearchRepositoryModelProtocol {
     private let searchUrl = "https://api.github.com/search/repositories?q=";
     
     enum SearchError: Error {
-        case TextIsEmpty
+        case TextEmpty
         case EncodeFailed
-        case URL
+        case URLInvalid
     }
     
-    func update(_ searchText: String) async throws -> (repositories: [Repository], results: [SearchResult]) {
+    func fetch(_ searchText: String) async throws -> (repositories: [Repository], results: [SearchResult]) {
         if searchText.count == 0 {
-            throw SearchError.TextIsEmpty
+            throw SearchError.TextEmpty
         }
         
         guard let encodedWord = searchText.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
             throw SearchError.EncodeFailed
         }
         guard let url = URL(string:"\(searchUrl)\(encodedWord)") else {
-            throw SearchError.URL
+            throw SearchError.URLInvalid
         }
         let (data, _) = try await URLSession.shared.data(from: url)
         let repositories = try JSONDecoder().decode(Repositories.self, from: data)

--- a/iOSEngineerCodeCheck/SearchRepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/SearchRepositoryPresenter.swift
@@ -1,5 +1,5 @@
 //
-//  RepositoryPresenter.swift
+//  SearchRepositoryPresenter.swift
 //  iOSEngineerCodeCheck
 //
 //  Created by Matsunobu Shun on 2021/10/19.

--- a/iOSEngineerCodeCheck/SearchRepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/SearchRepositoryPresenter.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol SearchRepositoryModelProtocol {
-    func update(_ searchText: String) async throws -> (repositories: [Repository], results: [SearchResult])
+    func fetch(_ searchText: String) async throws -> (repositories: [Repository], results: [SearchResult])
 }
 
 class SearchRepositoryPresenter: SearchPresenter {
@@ -35,7 +35,7 @@ class SearchRepositoryPresenter: SearchPresenter {
     }
     
     func update(_ searchText: String) async {
-        guard let (repositories, results) = try? await model.update(searchText) else {
+        guard let (repositories, results) = try? await model.fetch(searchText) else {
             return
         }
         self.repositories = repositories

--- a/iOSEngineerCodeCheck/SearchViewController.swift
+++ b/iOSEngineerCodeCheck/SearchViewController.swift
@@ -11,12 +11,18 @@ import UIKit
 struct SearchResult {
     var title: String
     var detail: String
+    
+    init(title: String, detail: String)
+    {
+        self.title = title
+        self.detail = detail
+    }
 }
 
 protocol SearchPresenter {
     var numberOfElement: Int { get }
     func update(_ searchText: String) async
-    func getElementByIndex(at: Int) -> SearchResult
+    func getElement(at index: Int) -> SearchResult
     func didSelectRow(at: Int) -> UIViewController
 }
 
@@ -26,6 +32,11 @@ class SearchViewController: UITableViewController {
     
     func inject(presenter: SearchPresenter) {
         self.presenter = presenter
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        inject(presenter: SearchRepositoryPresenter())
     }
     
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -44,7 +55,7 @@ class SearchViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let result = presenter.getElementByIndex(at: indexPath.row)
+        let result = presenter.getElement(at: indexPath.row)
         let cell = UITableViewCell()
         cell.textLabel?.text = result.title
         cell.detailTextLabel?.text = result.detail

--- a/iOSEngineerCodeCheck/SearchViewController.swift
+++ b/iOSEngineerCodeCheck/SearchViewController.swift
@@ -69,7 +69,7 @@ extension SearchViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let result = presenter.getElement(at: indexPath.row)
-        let cell = UITableViewCell()
+        let cell = UITableViewCell.init(style: UITableViewCell.CellStyle.value1, reuseIdentifier: String(indexPath.row))
         cell.textLabel?.text = result.title
         cell.detailTextLabel?.text = result.detail
         return cell

--- a/iOSEngineerCodeCheck/SearchViewController.swift
+++ b/iOSEngineerCodeCheck/SearchViewController.swift
@@ -7,6 +7,8 @@
 //
 
 import UIKit
+import Instantiate
+import InstantiateStandard
 
 struct SearchResult {
     var title: String
@@ -26,23 +28,21 @@ protocol SearchPresenter {
     func didSelectRow(at: Int) -> UIViewController
 }
 
-class SearchViewController: UIViewController {
+class SearchViewController: UIViewController, StoryboardInstantiatable {
+    
+    typealias Dependency = SearchPresenter
     
     @IBOutlet weak var searchBar: UISearchBar!
     @IBOutlet weak var tableView: UITableView!
     
     private var presenter: SearchPresenter!
     
-    func inject(presenter: SearchPresenter) {
-        self.presenter = presenter
+    func inject(_ dependency: SearchPresenter) {
+        self.presenter = dependency
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        let model = SearchRepositoryModel()
-        let presenter = SearchRepositoryPresenter(model: model)
-        inject(presenter: presenter)
         
         searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self

--- a/iOSEngineerCodeCheck/SearchViewController.swift
+++ b/iOSEngineerCodeCheck/SearchViewController.swift
@@ -39,7 +39,11 @@ class SearchViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        inject(presenter: SearchRepositoryPresenter())
+        
+        let model = SearchRepositoryModel()
+        let presenter = SearchRepositoryPresenter(model: model)
+        inject(presenter: presenter)
+        
         searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self
         tableView.delegate = self

--- a/iOSEngineerCodeCheck/SearchViewController.swift
+++ b/iOSEngineerCodeCheck/SearchViewController.swift
@@ -26,7 +26,10 @@ protocol SearchPresenter {
     func didSelectRow(at: Int) -> UIViewController
 }
 
-class SearchViewController: UITableViewController {
+class SearchViewController: UIViewController {
+    
+    @IBOutlet weak var searchBar: UISearchBar!
+    @IBOutlet weak var tableView: UITableView!
     
     private var presenter: SearchPresenter!
     
@@ -37,34 +40,35 @@ class SearchViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         inject(presenter: SearchRepositoryPresenter())
-    }
-    
-    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let searchBar = UISearchBar()
         searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self
-        return searchBar
+        tableView.delegate = self
+        tableView.dataSource = self
     }
     
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 44
+}
+
+extension SearchViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let vc = presenter.didSelectRow(at: indexPath.row)
+        self.navigationController?.pushViewController(vc, animated: true)
     }
     
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+}
+
+extension SearchViewController: UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return presenter.numberOfElement
     }
     
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let result = presenter.getElement(at: indexPath.row)
         let cell = UITableViewCell()
         cell.textLabel?.text = result.title
         cell.detailTextLabel?.text = result.detail
         return cell
-    }
-    
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let vc = presenter.didSelectRow(at: indexPath.row)
-        self.navigationController?.pushViewController(vc, animated: true)
     }
     
 }


### PR DESCRIPTION
* MVPアーキテクチャを導入
  SearchViewControllerはPresenterを差し替えることで、例えばUserなど、他の検索画面にも使用できるように記述
* 起動経路をSceneDelegateに記述
  Main InterfaceからStoryboardを読み込む形から、コード上での画面生成に修正
* 1Storyboard-1ViewControllerにする
  Instantiateパッケージを使用したかったこともあるが、すべての画面を1:1で管理するように修正
* UITableViewController継承だったSearchViewControllerをUIViewController継承に
  SearchBarもスクロールしてしまう問題をdelegateメソッドから無理やり解消していたが、Storyboard上で解決し、それぞれのdelegateをextension化するリファクタも行った
* SearchViewControllerのTableViewCellにlanguageが表示されていなかった不具合の修正